### PR TITLE
Added extra initialState property for reviving persisted FSM

### DIFF
--- a/dist/amd/machine.js
+++ b/dist/amd/machine.js
@@ -17,6 +17,7 @@ define(
       states:            null,
       activeTransitions: null,
       currentState:      null,
+      initialState:      null,
 
       init: function() {
         var target = this.get('target');
@@ -40,7 +41,7 @@ define(
 
         this.set('stateNames',   this.definition.stateNames);
         this.set('eventNames',   this.definition.eventNames);
-        this.set('currentState', this.definition.initialState);
+        this.set('currentState', this.get('initialState') || this.definition.initialState);
       },
 
       send: function(event) {

--- a/dist/amd/stateful.js
+++ b/dist/amd/stateful.js
@@ -10,6 +10,7 @@ define(
     __exports__["default"] = Mixin.create({
       stateEvents:  required(),
       states:       null,
+      initialState: null,
       isLoading:    computed.oneWay('__fsm__.isTransitioning'),
       currentState: computed.oneWay('__fsm__.currentState'),
 
@@ -21,6 +22,7 @@ define(
         params.target = this;
         params.events = this.get('stateEvents');
         params.states = this.get('states');
+        params.initialState = this.get('initialState');
 
         fsm = Machine.create(params);
 

--- a/dist/cjs/machine.js
+++ b/dist/cjs/machine.js
@@ -14,6 +14,7 @@ exports["default"] = Ember.Object.extend({
   states:            null,
   activeTransitions: null,
   currentState:      null,
+  initialState:      null,
 
   init: function() {
     var target = this.get('target');
@@ -37,7 +38,7 @@ exports["default"] = Ember.Object.extend({
 
     this.set('stateNames',   this.definition.stateNames);
     this.set('eventNames',   this.definition.eventNames);
-    this.set('currentState', this.definition.initialState);
+    this.set('currentState', this.get('initialState') || this.definition.initialState);
   },
 
   send: function(event) {

--- a/dist/cjs/stateful.js
+++ b/dist/cjs/stateful.js
@@ -7,6 +7,7 @@ var Machine = require("./machine")["default"] || require("./machine");
 exports["default"] = Mixin.create({
   stateEvents:  required(),
   states:       null,
+  initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),
   currentState: computed.oneWay('__fsm__.currentState'),
 
@@ -18,6 +19,7 @@ exports["default"] = Mixin.create({
     params.target = this;
     params.events = this.get('stateEvents');
     params.states = this.get('states');
+    params.initialState = this.get('initialState');
 
     fsm = Machine.create(params);
 

--- a/dist/globals/ember-fsm.js
+++ b/dist/globals/ember-fsm.js
@@ -638,6 +638,7 @@ exports["default"] = Ember.Object.extend({
   states:            null,
   activeTransitions: null,
   currentState:      null,
+  initialState:      null,
 
   init: function() {
     var target = this.get('target');
@@ -661,7 +662,7 @@ exports["default"] = Ember.Object.extend({
 
     this.set('stateNames',   this.definition.stateNames);
     this.set('eventNames',   this.definition.eventNames);
-    this.set('currentState', this.definition.initialState);
+    this.set('currentState', this.get('initialState') || this.definition.initialState);
   },
 
   send: function(event) {
@@ -905,6 +906,7 @@ var Machine = _dereq_("./machine")["default"] || _dereq_("./machine");
 exports["default"] = Mixin.create({
   stateEvents:  required(),
   states:       null,
+  initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),
   currentState: computed.oneWay('__fsm__.currentState'),
 
@@ -916,6 +918,7 @@ exports["default"] = Mixin.create({
     params.target = this;
     params.events = this.get('stateEvents');
     params.states = this.get('states');
+    params.initialState = this.get('initialState');
 
     fsm = Machine.create(params);
 

--- a/dist/named-amd/ember-fsm.js
+++ b/dist/named-amd/ember-fsm.js
@@ -646,6 +646,7 @@ define("ember-fsm/machine",
       states:            null,
       activeTransitions: null,
       currentState:      null,
+      initialState:      null,
 
       init: function() {
         var target = this.get('target');
@@ -669,7 +670,7 @@ define("ember-fsm/machine",
 
         this.set('stateNames',   this.definition.stateNames);
         this.set('eventNames',   this.definition.eventNames);
-        this.set('currentState', this.definition.initialState);
+        this.set('currentState', this.get('initialState') || this.definition.initialState);
       },
 
       send: function(event) {
@@ -919,6 +920,7 @@ define("ember-fsm/stateful",
     __exports__["default"] = Mixin.create({
       stateEvents:  required(),
       states:       null,
+      initialState: null,
       isLoading:    computed.oneWay('__fsm__.isTransitioning'),
       currentState: computed.oneWay('__fsm__.currentState'),
 
@@ -930,6 +932,7 @@ define("ember-fsm/stateful",
         params.target = this;
         params.events = this.get('stateEvents');
         params.states = this.get('states');
+        params.initialState = this.get('initialState');
 
         fsm = Machine.create(params);
 

--- a/lib/machine.js
+++ b/lib/machine.js
@@ -10,6 +10,7 @@ export default Ember.Object.extend({
   states:            null,
   activeTransitions: null,
   currentState:      null,
+  initialState:      null,
 
   init: function() {
     var target = this.get('target');
@@ -33,7 +34,7 @@ export default Ember.Object.extend({
 
     this.set('stateNames',   this.definition.stateNames);
     this.set('eventNames',   this.definition.eventNames);
-    this.set('currentState', this.definition.initialState);
+    this.set('currentState', this.get('initialState') || this.definition.initialState);
   },
 
   send: function(event) {

--- a/lib/stateful.js
+++ b/lib/stateful.js
@@ -4,6 +4,7 @@ import Machine from './machine';
 export default Mixin.create({
   stateEvents:  required(),
   states:       null,
+  initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),
   currentState: computed.oneWay('__fsm__.currentState'),
 
@@ -15,6 +16,7 @@ export default Mixin.create({
     params.target = this;
     params.events = this.get('stateEvents');
     params.states = this.get('states');
+    params.initialState = this.get('initialState');
 
     fsm = Machine.create(params);
 

--- a/test/machine-spec.js
+++ b/test/machine-spec.js
@@ -31,6 +31,21 @@ describe('FSM.Machine', function() {
       expect(fsm.get('currentState')).toBe('ready');
     });
 
+    it('sets the currentState to the overruled initialState', function() {
+      var fsm = createMachine({
+        initialState: 'done',
+        states: {
+          initialState: 'ready',
+        },
+        events: {
+          one: { transition: { ready: 'a' } },
+          two: { transition: { done: 'b' } },
+        }
+      });
+
+      expect(fsm.get('currentState')).toBe('done');
+    });
+
     it('does not destruct original definition', function() {
       var FSM;
       var fsm0;

--- a/test/stateful-spec.js
+++ b/test/stateful-spec.js
@@ -1,9 +1,10 @@
 describe('FSM.Stateful', function() {
   var so;
   var fsm;
+  var sO;
 
   beforeEach(function() {
-    var sO = Em.Object.extend(Em.FSM.Stateful, {
+    sO = Em.Object.extend(Em.FSM.Stateful, {
       states: {
         initialState: 'cool'
       },
@@ -23,6 +24,11 @@ describe('FSM.Stateful', function() {
 
   it('provides currentState', function() {
     expect(so.get('currentState')).toBe('cool');
+  });
+
+  it('can override the initial state', function() {
+    so = sO.create({initialState: 'herp'});
+    expect(so.get('currentState')).toBe('herp');
   });
 
   it('provides isLoading', function() {


### PR DESCRIPTION
This code allows to overwrite `initialState` with another state. When an FSM is restored after storing to a DB, this way it can continue from where it was persisted.

Another approach would be to move `state.initialState` property out of the definition and into the machine, but that would break compatibilty.
