### PR TITLE
Ember 1.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ want to use `Ember.FSM.Stateful` over sub-classing `Ember.FSM.Machine`. This way
 you can formalize a state workflow around something like file uploads where you
 might have to incorporate three different proceesses into on user experience.
 
+Note states and events are renamed in the mixin to `fsmStates` and `fsmEvents`
+respectively, to avoid conflict with core Ember properties.
+
 Building these sorts of workflows implicitly as-you-code-along can be a recipie
 for massive sadness. So why be sad? Formalize that workflow! Here's an example
 of how adding `Ember.FSM.Stateful` to a controller can remove a lot of the
@@ -201,11 +204,11 @@ App.UploadController = Em.Controller.extend(Em.FSM.Stateful, {
     }
   },
 
-  states: {
+  fsmStates: {
     initialState: 'nofile'
   },
 
-  stateEvents: {
+  fsmEvents: {
     addFile: {
       transitions: {
         from:   ['nofile', 'failed'],

--- a/lib/stateful.js
+++ b/lib/stateful.js
@@ -2,8 +2,8 @@ import { Mixin, required, computed } from 'ember';
 import Machine from './machine';
 
 export default Mixin.create({
-  stateEvents:  required(),
-  states:       null,
+  fsmEvents:    required(),
+  fsmStates:    null,
   initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),
   currentState: computed.oneWay('__fsm__.currentState'),
@@ -14,8 +14,8 @@ export default Mixin.create({
     var fsm;
 
     params.target = this;
-    params.events = this.get('stateEvents');
-    params.states = this.get('states');
+    params.events = this.get('fsmEvents');
+    params.states = this.get('fsmStates');
     params.initialState = this.get('initialState');
 
     fsm = Machine.create(params);

--- a/test/stateful-spec.js
+++ b/test/stateful-spec.js
@@ -5,11 +5,11 @@ describe('FSM.Stateful', function() {
 
   beforeEach(function() {
     sO = Em.Object.extend(Em.FSM.Stateful, {
-      states: {
+      fsmStates: {
         initialState: 'cool'
       },
 
-      stateEvents: {
+      fsmEvents: {
         blerp: { transition: { cool: 'herp' } }
       }
     });


### PR DESCRIPTION
Rename `Ember.FSM.Stateful.{states,stateEvents}` to `{fsmStates,fsmEvents}` for Ember 1.8 compatibility. #7

`states` is already property on Ember.CoreView.

Breaks existing clients of `Ember.FSM.Stateful`, unfortunately.
