### PR TITLE
`Ember.required` deprecated

### DIFF
--- a/dist/amd/stateful.js
+++ b/dist/amd/stateful.js
@@ -3,12 +3,11 @@ define(
   function(__dependency1__, __dependency2__, __exports__) {
     "use strict";
     var Mixin = __dependency1__.Mixin;
-    var required = __dependency1__.required;
     var computed = __dependency1__.computed;
     var Machine = __dependency2__["default"] || __dependency2__;
 
     __exports__["default"] = Mixin.create({
-      fsmEvents:    required(),
+      fsmEvents:    null,
       fsmStates:    null,
       initialState: null,
       isLoading:    computed.oneWay('__fsm__.isTransitioning'),

--- a/dist/cjs/stateful.js
+++ b/dist/cjs/stateful.js
@@ -1,11 +1,10 @@
 "use strict";
 var Mixin = require("ember").Mixin;
-var required = require("ember").required;
 var computed = require("ember").computed;
 var Machine = require("./machine")["default"] || require("./machine");
 
 exports["default"] = Mixin.create({
-  fsmEvents:    required(),
+  fsmEvents:    null,
   fsmStates:    null,
   initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),

--- a/dist/globals/ember-fsm.js
+++ b/dist/globals/ember-fsm.js
@@ -899,12 +899,11 @@ exports.reject = reject;
 },{}],5:[function(_dereq_,module,exports){
 "use strict";
 var Mixin = window.Ember.Mixin;
-var required = window.Ember.required;
 var computed = window.Ember.computed;
 var Machine = _dereq_("./machine")["default"] || _dereq_("./machine");
 
 exports["default"] = Mixin.create({
-  fsmEvents:    required(),
+  fsmEvents:    null,
   fsmStates:    null,
   initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),

--- a/dist/named-amd/ember-fsm.js
+++ b/dist/named-amd/ember-fsm.js
@@ -913,12 +913,11 @@ define("ember-fsm/stateful",
   function(__dependency1__, __dependency2__, __exports__) {
     "use strict";
     var Mixin = __dependency1__.Mixin;
-    var required = __dependency1__.required;
     var computed = __dependency1__.computed;
     var Machine = __dependency2__["default"] || __dependency2__;
 
     __exports__["default"] = Mixin.create({
-      fsmEvents:    required(),
+      fsmEvents:    null,
       fsmStates:    null,
       initialState: null,
       isLoading:    computed.oneWay('__fsm__.isTransitioning'),

--- a/lib/stateful.js
+++ b/lib/stateful.js
@@ -1,8 +1,8 @@
-import { Mixin, required, computed } from 'ember';
+import { Mixin, computed } from 'ember';
 import Machine from './machine';
 
 export default Mixin.create({
-  fsmEvents:    required(),
+  fsmEvents:    null,
   fsmStates:    null,
   initialState: null,
   isLoading:    computed.oneWay('__fsm__.isTransitioning'),


### PR DESCRIPTION
Remove `Ember.required` as it has been deprecated in Ember.  Getting this warning in 1.12.x beta.

I've just simply removed the call to `Ember.required` -- Would you like to do something more?

_Edit: Add version information_