### PR TITLE
Add fsm prefix to stateful mixin properties

### DIFF
--- a/dist/amd/stateful.js
+++ b/dist/amd/stateful.js
@@ -4,38 +4,40 @@ define(
     "use strict";
     var Mixin = __dependency1__.Mixin;
     var computed = __dependency1__.computed;
+
     var Machine = __dependency2__["default"] || __dependency2__;
 
+    
     __exports__["default"] = Mixin.create({
-      fsmEvents:    null,
-      fsmStates:    null,
-      initialState: null,
-      isLoading:    computed.oneWay('__fsm__.isTransitioning'),
-      currentState: computed.oneWay('__fsm__.currentState'),
-
+      fsmEvents:       null,
+      fsmStates:       null,
+      fsmInitialState: null,
+      fsmIsLoading:    computed.oneWay('__fsm__.isTransitioning'),
+      fsmCurrentState: computed.oneWay('__fsm__.currentState'),
+    
       init: function() {
         var params = {};
         var mixin  = {};
         var fsm;
-
+    
         params.target = this;
         params.events = this.get('fsmEvents');
         params.states = this.get('fsmStates');
-        params.initialState = this.get('initialState');
-
+        params.initialState = this.get('fsmInitialState');
+    
         fsm = Machine.create(params);
-
+    
         this.set('__fsm__', fsm);
-
+    
         fsm.isInStateAccessorProperties.forEach(function(prop) {
           mixin[prop] = computed.oneWay('__fsm__.' + prop);
         });
-
+    
         this.reopen(mixin);
-
+    
         this._super();
       },
-
+    
       sendStateEvent: function() {
         var fsm = this.get('__fsm__');
         return fsm.send.apply(fsm, arguments);

--- a/dist/cjs/stateful.js
+++ b/dist/cjs/stateful.js
@@ -4,11 +4,11 @@ var computed = require("ember").computed;
 var Machine = require("./machine")["default"] || require("./machine");
 
 exports["default"] = Mixin.create({
-  fsmEvents:    null,
-  fsmStates:    null,
-  initialState: null,
-  isLoading:    computed.oneWay('__fsm__.isTransitioning'),
-  currentState: computed.oneWay('__fsm__.currentState'),
+  fsmEvents:       null,
+  fsmStates:       null,
+  fsmInitialState: null,
+  fsmIsLoading:    computed.oneWay('__fsm__.isTransitioning'),
+  fsmCurrentState: computed.oneWay('__fsm__.currentState'),
 
   init: function() {
     var params = {};
@@ -18,7 +18,7 @@ exports["default"] = Mixin.create({
     params.target = this;
     params.events = this.get('fsmEvents');
     params.states = this.get('fsmStates');
-    params.initialState = this.get('initialState');
+    params.initialState = this.get('fsmInitialState');
 
     fsm = Machine.create(params);
 

--- a/dist/globals/ember-fsm.js
+++ b/dist/globals/ember-fsm.js
@@ -905,11 +905,11 @@ var computed = window.Ember.computed;
 var Machine = _dereq_("./machine")["default"] || _dereq_("./machine");
 
 exports["default"] = Mixin.create({
-  fsmEvents:    null,
-  fsmStates:    null,
-  initialState: null,
-  isLoading:    computed.oneWay('__fsm__.isTransitioning'),
-  currentState: computed.oneWay('__fsm__.currentState'),
+  fsmEvents:       null,
+  fsmStates:       null,
+  fsmInitialState: null,
+  fsmIsLoading:    computed.oneWay('__fsm__.isTransitioning'),
+  fsmCurrentState: computed.oneWay('__fsm__.currentState'),
 
   init: function() {
     var params = {};
@@ -919,7 +919,7 @@ exports["default"] = Mixin.create({
     params.target = this;
     params.events = this.get('fsmEvents');
     params.states = this.get('fsmStates');
-    params.initialState = this.get('initialState');
+    params.initialState = this.get('fsmInitialState');
 
     fsm = Machine.create(params);
 

--- a/dist/named-amd/ember-fsm.js
+++ b/dist/named-amd/ember-fsm.js
@@ -919,12 +919,12 @@ define("ember-fsm/stateful",
     var Machine = __dependency2__["default"] || __dependency2__;
 
     __exports__["default"] = Mixin.create({
-      fsmEvents:    null,
-      fsmStates:    null,
-      initialState: null,
-      isLoading:    computed.oneWay('__fsm__.isTransitioning'),
-      currentState: computed.oneWay('__fsm__.currentState'),
-
+      fsmEvents:       null,
+      fsmStates:       null,
+      fsmInitialState: null,
+      fsmIsLoading:    computed.oneWay('__fsm__.isTransitioning'),
+      fsmCurrentState: computed.oneWay('__fsm__.currentState'),
+    
       init: function() {
         var params = {};
         var mixin  = {};
@@ -933,8 +933,8 @@ define("ember-fsm/stateful",
         params.target = this;
         params.events = this.get('fsmEvents');
         params.states = this.get('fsmStates');
-        params.initialState = this.get('initialState');
-
+        params.initialState = this.get('fsmInitialState');
+    
         fsm = Machine.create(params);
 
         this.set('__fsm__', fsm);

--- a/lib/stateful.js
+++ b/lib/stateful.js
@@ -2,11 +2,11 @@ import { Mixin, computed } from 'ember';
 import Machine from './machine';
 
 export default Mixin.create({
-  fsmEvents:    null,
-  fsmStates:    null,
-  initialState: null,
-  isLoading:    computed.oneWay('__fsm__.isTransitioning'),
-  currentState: computed.oneWay('__fsm__.currentState'),
+  fsmEvents:       null,
+  fsmStates:       null,
+  fsmInitialState: null,
+  fsmIsLoading:    computed.oneWay('__fsm__.isTransitioning'),
+  fsmCurrentState: computed.oneWay('__fsm__.currentState'),
 
   init: function() {
     var params = {};
@@ -16,7 +16,7 @@ export default Mixin.create({
     params.target = this;
     params.events = this.get('fsmEvents');
     params.states = this.get('fsmStates');
-    params.initialState = this.get('initialState');
+    params.initialState = this.get('fsmInitialState');
 
     fsm = Machine.create(params);
 

--- a/test/stateful-spec.js
+++ b/test/stateful-spec.js
@@ -22,19 +22,19 @@ describe('FSM.Stateful', function() {
     expect(so).toBe(fsm.get('target'));
   });
 
-  it('provides currentState', function() {
-    expect(so.get('currentState')).toBe('cool');
+  it('provides fsmCurrentState', function() {
+    expect(so.get('fsmCurrentState')).toBe('cool');
   });
 
   it('can override the initial state', function() {
-    so = sO.create({initialState: 'herp'});
-    expect(so.get('currentState')).toBe('herp');
+    so = sO.create({fsmInitialState: 'herp'});
+    expect(so.get('fsmCurrentState')).toBe('herp');
   });
 
-  it('provides isLoading', function() {
-    expect(so.get('isLoading')).toBe(false);
+  it('provides fsmIsLoading', function() {
+    expect(so.get('fsmIsLoading')).toBe(false);
     fsm.pushActiveTransition('t0');
-    expect(so.get('isLoading')).toBe(true);
+    expect(so.get('fsmIsLoading')).toBe(true);
   });
 
   it('provides isIn{{State}} accessors', function() {
@@ -45,7 +45,7 @@ describe('FSM.Stateful', function() {
   it('delegates sendStateEvent to fsm.send', function(done) {
     so.sendStateEvent('blerp').then(function() {
       Em.run.next(function() {
-        expect(so.get('currentState')).toBe('herp');
+        expect(so.get('fsmCurrentState')).toBe('herp');
         done();
       });
     });


### PR DESCRIPTION
This might be a simplistic way of solving this problem, but I think it's clearer than property sniffing: having to use different property names depending on whether you were using the mixin in a component or some other type seems a little yucky.