### PR TITLE
Destructure RSVP as well as Promise

### DIFF
--- a/addon/transition.js
+++ b/addon/transition.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { withPromise, bind } from './utils';
 
 const {
+  RSVP,
   RSVP: { Promise },
   computed,
   inspect,


### PR DESCRIPTION
Ensures that `RSVP` is also destructured from `Ember`, so that it's possible to call methods on it (`RSVP.hash`, etc).

@heycarsten, alternatively if you prefer, we can destructure the other individual methods from `RSVP` (`reject` and `hash`). Happy either way.